### PR TITLE
feat!: automatically read forwarded header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.MD"
 
 [dependencies]
 http = "1.0.0"
-lru = { version = "0.12.5", optional = true }
 pin-project = "1.1.3"
 regex = { version = "1.10.3", optional = true }
 thiserror = "1.0.44"
@@ -30,7 +29,6 @@ tower = { version = "0.5.0", features = ["util"] }
 
 [features]
 default = ["tracing"]
-cache = ["dep:lru"]
 regex = ["dep:regex"]
 tracing = ["dep:tracing"]
 wildcard = ["dep:wildmatch"]

--- a/README.MD
+++ b/README.MD
@@ -26,7 +26,7 @@ To restrict access to specific basic hosts, you can use the following code:
 
 ```rust
 let tower_layer = tower_allowed_hosts::AllowedHostLayer::default()
-    .extend(&["127.0.0.1".to_string()]);
+    .extend_allowed_hosts(&["127.0.0.1".to_string()]);
 ```
 
 ### Wildcard
@@ -42,7 +42,7 @@ You can then restrict hosts using wildcards:
 
 ```rust
 let tower_layer = tower_allowed_hosts::AllowedHostLayer::default()
-    .extend(&[wildmatch::WildMatch::new("127.0.0.*")]);
+    .extend_allowed_hosts(&[wildmatch::WildMatch::new("127.0.0.*")]);
 ```
 
 ### Regex
@@ -77,7 +77,7 @@ fn router() -> Router {
     let handle_error_layer = HandleErrorLayer::new(handle_box_error);
 
     let allowed_hosts_layer = AllowedHostLayer::default()
-        .extend(&[wildmatch::WildMatch::new("127.0.0.*")]);
+        .extend_allowed_hosts(&[wildmatch::WildMatch::new("127.0.0.*")]);
 
      let layer = ServiceBuilder::new()
         .layer(handle_error_layer)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,20 @@
 /// Enum for different error generated from crates
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum Error {
-    /// error when host is failed to resolve
-    #[error("failed to resolve host")]
-    FailedToResolveHost,
     /// error raised when host is not allowed
     #[error("host {0} not allowed")]
     HostNotAllowed(String),
+    /// error when passed forwarded header is invalid
+    #[error("invalid forwarded header")]
+    InvalidForwardedHeader,
+    /// error when passed host header is invalid
+    #[error("invalid host header")]
+    InvalidHostHeader,
+    /// error when passed host header is missing
+    #[error("missing host header")]
+    MissingHostHeader,
+    /// error when there is multiple host header
+    #[error("multiple host header")]
+    MultipleHostHeader,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,14 @@
 //!
 //! # Examples
 //! ```rust
-//! let layer = tower_allowed_hosts::AllowedHostLayer::new(["127.0.0.1", "localhost"]);
+//! let layer = tower_allowed_hosts::AllowedHostLayer::<_, String>::default()
+//!     .extend_allowed_hosts(vec!["example.com"]);
 //! ```
 //!
 //! Check `README.MD` or documentation of [`AllowedHostLayer`] for more detailed
 //! information
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[doc(inline)]
-pub use matcher::Matcher;
 #[doc(inline)]
 pub use service::AllowedHostLayer;
 
@@ -29,7 +28,7 @@ pub mod service;
 #[cfg(test)]
 mod tests;
 
-/// Struct which holds value of host along with its port in form of authority.
+/// Struct which holds value of host
 ///
 /// This struct is added as a extension to request after successfully resolving
 /// host and verifying host is valid host which can be used in server if needed

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -5,19 +5,19 @@ use wildmatch::WildMatchPattern;
 
 /// Trait for matcher
 pub trait Matcher {
-    /// Check if provided host value matches with matcher
-    fn matches_host(&self, host: &str) -> bool;
+    /// Check if provided value value matches with matcher
+    fn matches_value(&self, value: &str) -> bool;
 }
 
 impl Matcher for String {
-    fn matches_host(&self, host: &str) -> bool {
-        self.eq(host)
+    fn matches_value(&self, value: &str) -> bool {
+        self.eq(value)
     }
 }
 
 impl Matcher for &str {
-    fn matches_host(&self, host: &str) -> bool {
-        self.eq(&host)
+    fn matches_value(&self, value: &str) -> bool {
+        self.eq(&value)
     }
 }
 
@@ -25,14 +25,14 @@ impl Matcher for &str {
 impl<const MULTI_WILDCARD: char, const SINGLE_WILDCARD: char> Matcher
     for WildMatchPattern<MULTI_WILDCARD, SINGLE_WILDCARD>
 {
-    fn matches_host(&self, host: &str) -> bool {
-        self.matches(host)
+    fn matches_value(&self, value: &str) -> bool {
+        self.matches(value)
     }
 }
 
 #[cfg(feature = "regex")]
 impl Matcher for Regex {
-    fn matches_host(&self, host: &str) -> bool {
-        self.is_match(host)
+    fn matches_value(&self, value: &str) -> bool {
+        self.is_match(value)
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,8 +21,9 @@ async fn inner_svc(_: Request<BoxBody>) -> Result<Response<BoxBody>, Infallible>
 
 #[tokio::test]
 async fn normal() {
-    let allowed_host_layer: AllowedHostLayer<String> =
-        AllowedHostLayer::default().extend(["127.0.0.1".to_string()]);
+    let allowed_host_layer: AllowedHostLayer<String, &str> = AllowedHostLayer::<_, &str>::default()
+        .extend_allowed_hosts(["127.0.0.1".to_string()])
+        .extend_allowed_forwarded_token_value([("signature".to_string(), "random_value")]);
     let svc = allowed_host_layer.layer(service_fn(inner_svc));
 
     let empty_res = svc.clone().oneshot(Request::new(empty_body())).await;
@@ -55,31 +56,23 @@ async fn normal() {
         .oneshot(
             Request::builder()
                 .header("HOST", "127.0.0.2")
-                .header("FORWARDED", "host=127.0.0.1")
-                .header("X-FORWARDED-HOST", "127.0.0.1")
+                .header("FORWARDED", "host=127.0.0.11")
                 .body(empty_body())
                 .unwrap(),
         )
         .await;
     assert!(invalid_host_header_res.is_err());
-}
-
-#[tokio::test]
-async fn normal_forwarded() {
-    let allowed_host_layer = AllowedHostLayer::default()
-        .set_use_forwarded(true)
-        .push("example.com");
-    let svc = allowed_host_layer.layer(service_fn(inner_svc));
 
     let valid_host_header_res = svc
         .clone()
         .oneshot(
             Request::builder()
+                .header("HOST", "127.0.0.1")
                 .header("FORWARDED", "host=example.com")
                 .header(
                     "FORWARDED",
-                    "for=10.0.10.11;by=10.1.12.11;host=127.0.0.30,for=10.0.10.11;by=10.1.12.11;\
-                     host=127.0.0.3",
+                    "for=10.0.10.11;by=10.1.12.11;host=127.0.0.1;signature=random_value,for=10.0.\
+                     10.11;by=10.1.12.11;host=127.0.0.3",
                 )
                 .body(empty_body())
                 .unwrap(),
@@ -91,7 +84,10 @@ async fn normal_forwarded() {
         .clone()
         .oneshot(
             Request::builder()
-                .header("FORWARDED", "for=10.0.10.11;by=10.1.12.11;host=127.0.0.2")
+                .header(
+                    "FORWARDED",
+                    "for=10.0.10.11;by=10.1.12.11;host=127.0.0.2;signature=random_value",
+                )
                 .header(
                     "FORWARDED",
                     "for=10.0.10.11;by=10.1.12.11;host=127.0.0.3,for=10.0.10.11;by=10.1.12.11;\
@@ -104,90 +100,11 @@ async fn normal_forwarded() {
     assert!(invalid_host_header_res.is_err());
 }
 
-#[tokio::test]
-async fn normal_x_forwarded() {
-    let allowed_host_layer = AllowedHostLayer::default()
-        .set_use_x_forwarded_host(true)
-        .extend(["127.10.0.1"]);
-    let svc = allowed_host_layer.layer(service_fn(inner_svc));
-
-    let valid_host_header_res = svc
-        .clone()
-        .oneshot(
-            Request::builder()
-                .header("FORWARDED", "host=127.10.0.1")
-                .header("X-FORWARDED-HOST", "127.10.0.1,127.0.0.2")
-                .body(empty_body())
-                .unwrap(),
-        )
-        .await;
-    assert!(valid_host_header_res.is_ok());
-
-    let invalid_host_header_res = svc
-        .clone()
-        .oneshot(
-            Request::builder()
-                .header("FORWARDED", "for=10.0.10.11;by=10.1.12.11;host=127.10.0.10")
-                .header("X-FORWARDED-HOST", "127.0.0.2,127.10.0.1")
-                .body(empty_body())
-                .unwrap(),
-        )
-        .await;
-    assert!(invalid_host_header_res.is_err());
-}
-
-#[tokio::test]
-async fn reject_multiples() {
-    let allowed_host_layer = AllowedHostLayer::default()
-        .set_reject_multiple_hosts(true)
-        .set_use_forwarded(true)
-        .extend(["127.0.0.1"]);
-    let svc = allowed_host_layer.layer(service_fn(inner_svc));
-
-    let single = svc
-        .clone()
-        .oneshot(
-            Request::builder()
-                .header("FORWARDED", "for=10.0.10.11;by=10.1.12.11;host=127.0.0.1")
-                .body(empty_body())
-                .unwrap(),
-        )
-        .await;
-    assert!(single.is_ok());
-
-    let multiple_comma = svc
-        .clone()
-        .oneshot(
-            Request::builder()
-                .header(
-                    "FORWARDED",
-                    "for=10.0.10.11;by=10.1.12.11;host=127.0.0.1,for=10.0.10.11;by=10.1.12.11;\
-                     host=127.0.0.10",
-                )
-                .body(empty_body())
-                .unwrap(),
-        )
-        .await;
-    assert!(multiple_comma.is_err());
-
-    let multiple_header = svc
-        .clone()
-        .oneshot(
-            Request::builder()
-                .header("FORWARDED", "for=10.0.10.11;by=10.1.12.11;host=127.0.0.1")
-                .header("FORWARDED", "for=10.0.10.11;by=10.1.12.11;host=127.0.0.10")
-                .body(empty_body())
-                .unwrap(),
-        )
-        .await;
-    assert!(multiple_header.is_err());
-}
-
 #[cfg(feature = "wildcard")]
 #[tokio::test]
 async fn wildcard() {
-    let allowed_host_layer =
-        AllowedHostLayer::default().push(wildmatch::WildMatch::new("127.0.0.?"));
+    let allowed_host_layer = AllowedHostLayer::<_, String>::default()
+        .push_allowed_hosts(wildmatch::WildMatch::new("127.0.0.?"));
     let svc = allowed_host_layer.layer(service_fn(inner_svc));
 
     let empty_res = svc.clone().oneshot(Request::new(empty_body())).await;
@@ -230,8 +147,8 @@ async fn wildcard() {
 #[cfg(feature = "regex")]
 #[tokio::test]
 async fn regex() {
-    let allowed_host_layer =
-        AllowedHostLayer::new([regex::Regex::new("^[a-z]+.example.com$").unwrap()]);
+    let allowed_host_layer = AllowedHostLayer::<_, String>::default()
+        .push_allowed_hosts(regex::Regex::new("^[a-z]+.example.com$").unwrap());
     let svc = allowed_host_layer.layer(service_fn(inner_svc));
 
     let empty_res = svc.clone().oneshot(Request::new(empty_body())).await;
@@ -291,49 +208,4 @@ async fn regex() {
         )
         .await;
     assert!(issue_no_3.is_err());
-}
-
-#[cfg(feature = "cache")]
-#[tokio::test]
-async fn cache() {
-    let allowed_host_layer = AllowedHostLayer::default()
-        .set_cap_size(std::num::NonZeroUsize::new(8).unwrap())
-        .push("127.0.0.1");
-    let svc = allowed_host_layer.layer(service_fn(inner_svc));
-
-    let empty_res = svc.clone().oneshot(Request::new(empty_body())).await;
-    assert!(empty_res.is_err());
-
-    let valid_host_header_res = svc
-        .clone()
-        .oneshot(
-            Request::builder()
-                .header("HOST", "127.0.0.1")
-                .body(empty_body())
-                .unwrap(),
-        )
-        .await;
-    assert!(valid_host_header_res.is_ok());
-
-    let from_cache = svc
-        .clone()
-        .oneshot(
-            Request::builder()
-                .header("HOST", "127.0.0.1")
-                .body(empty_body())
-                .unwrap(),
-        )
-        .await;
-    assert!(from_cache.is_ok());
-
-    let issue_header = svc
-        .clone()
-        .oneshot(
-            Request::builder()
-                .header("HOST", "127.0.0.20")
-                .body(empty_body())
-                .unwrap(),
-        )
-        .await;
-    assert!(issue_header.is_err());
 }


### PR DESCRIPTION
- add support to read forwarded host value from forwarded header which token value combination matches
- remove supported for x-forwarded-host since it is not standard
- remove caching support
- improce logic