### PR TITLE
refactor!: change struct of allowed host layer

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -24,8 +24,7 @@ tower_allowed_hosts = "0.9.2"
 To restrict access to specific basic hosts, you can use the following code:
 
 ```rust
-let tower_layer = tower_allowed_hosts::AllowedHostLayer::default()
-    .extend_hosts(&["127.0.0.1".to_string()]);
+let tower_layer = tower_allowed_hosts::AllowedHostLayer::new("127.0.0.1");
 ```
 
 ### Wildcard
@@ -40,8 +39,7 @@ tower_allowed_hosts = { version = "0.9.2", features = ["wildcard"] }
 You can then restrict hosts using wildcards:
 
 ```rust
-let tower_layer = tower_allowed_hosts::AllowedHostLayer::default()
-    .extend_hosts(&[wildmatch::WildMatch::new("127.0.0.*")]);
+let tower_layer = tower_allowed_hosts::AllowedHostLayer::new(wildmatch::WildMatch::new("127.0.0.*"));
 ```
 
 ### Regex
@@ -56,7 +54,15 @@ tower_allowed_hosts = { version = "0.9.2", features = ["regex"] }
 You can then restrict hosts using regex patterns:
 
 ```rust
-let tower_layer = tower_allowed_hosts::AllowedHostLayer::new(&[regex::Regex::new("^127.0.0.1$")?]);
+let tower_layer = tower_allowed_hosts::AllowedHostLayer::new(regex::Regex::new("^127.0.0.1$")?);
+```
+
+### Forwarded header
+If you wish to also handle `Forwarded` header than you can extend created `AllowedHostLayer` with `with_forwarded_matcher`
+
+```rust
+let layer = tower_allowed_hosts::AllowedHostLayer::new("example.com")
+    .with_forwarded_matcher(("by", "example.org"));
 ```
 
 # Integrating with a Tower-Compatible Library
@@ -75,8 +81,7 @@ use tower_allowed_hosts::AllowedHostLayer;
 fn router() -> Router {
     let handle_error_layer = HandleErrorLayer::new(handle_box_error);
 
-    let allowed_hosts_layer = AllowedHostLayer::default()
-        .extend_hosts(&[wildmatch::WildMatch::new("127.0.0.*")]);
+    let allowed_hosts_layer = AllowedHostLayer::new(wildmatch::WildMatch::new("127.0.0.*"));
 
      let layer = ServiceBuilder::new()
         .layer(handle_error_layer)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,7 @@
 //!
 //! # Examples
 //! ```rust
-//! let layer =
-//!     tower_allowed_hosts::AllowedHostLayer::<_, ()>::default().extend_hosts(vec!["example.com"]);
+//! let layer = tower_allowed_hosts::AllowedHostLayer::new("example.com");
 //! ```
 //!
 //! Check `README.MD` or documentation of [`AllowedHostLayer`] for more detailed

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,30 +1,112 @@
+use std::collections::HashMap;
+
 #[cfg(feature = "regex")]
 use regex::Regex;
 #[cfg(feature = "wildcard")]
 use wildmatch::WildMatchPattern;
 
-/// Trait for checking if a given value matches a specific pattern.
+/// Trait for matching against the value
 ///
-/// `Matcher` trait is currently used in two places checking `Host` header as
-/// well as `Forwarded` header value. Both can have custom `Matcher` which
-/// differs from each others
-///
-/// The `Matcher` trait is designed to be highly versatile and extensible,
-/// allowing it to be implemented for a variety of pattern matching scenarios.
-/// Beyond simple string comparisons `Matcher` can be extended to support
-/// complex operations according to requirements
-pub trait Matcher: Clone {
+/// A `Matcher` is responsible for checking whether a given value is consider to
+/// match with a provided matcher
+pub trait Matcher {
     /// Checks if provided value matches according to matcher
     fn matches_value(&self, value: &str) -> bool;
 }
 
-/// Asterisk matcher which always returns true and matches any host
-#[derive(Clone)]
-pub struct Asterisk;
+/// Trait for matching the presence and values of parameters in a `Forwarded`
+/// header.
+///
+/// When `AllowedHostLayer` is configured with a `KeyValueMatcher`, it will
+/// only consider the `host=` value from a `Forwarded` header if the matcher
+/// determines that the header’s parameters are acceptable.
+///
+/// The matcher receives a map of all key–value pairs in the `Forwarded` entry
+/// (e.g. `for=...;by=...;host=...;token=value`)
+pub trait KeyValueMatcher {
+    /// Checks if provided value matches according to matcher
+    fn matches_key_value(&self, values: &HashMap<String, String>) -> bool;
+}
 
-impl Matcher for Asterisk {
+/// Any matcher which always returns true and matches any host
+#[derive(Clone)]
+pub struct Any;
+
+impl Matcher for Any {
     fn matches_value(&self, _value: &str) -> bool {
         true
+    }
+}
+
+impl KeyValueMatcher for Any {
+    fn matches_key_value(&self, _values: &HashMap<String, String>) -> bool {
+        true
+    }
+}
+
+/// And matcher which matches only when both left and right matches
+pub struct And<L, R> {
+    left: L,
+    right: R,
+}
+
+impl<L, R> And<L, R> {
+    /// Create new and matcher
+    pub fn new(left: L, right: R) -> Self {
+        Self { left, right }
+    }
+}
+
+impl<L, R> Matcher for And<L, R>
+where
+    L: Matcher,
+    R: Matcher,
+{
+    fn matches_value(&self, value: &str) -> bool {
+        self.left.matches_value(value) && self.right.matches_value(value)
+    }
+}
+
+impl<L, R> KeyValueMatcher for And<L, R>
+where
+    L: KeyValueMatcher,
+    R: KeyValueMatcher,
+{
+    fn matches_key_value(&self, values: &HashMap<String, String>) -> bool {
+        self.left.matches_key_value(values) && self.right.matches_key_value(values)
+    }
+}
+
+/// Or matcher which matches when either left and right matches
+pub struct Or<L, R> {
+    left: L,
+    right: R,
+}
+
+impl<L, R> Or<L, R> {
+    /// Create new or matcher
+    pub fn new(left: L, right: R) -> Self {
+        Self { left, right }
+    }
+}
+
+impl<L, R> KeyValueMatcher for Or<L, R>
+where
+    L: KeyValueMatcher,
+    R: KeyValueMatcher,
+{
+    fn matches_key_value(&self, values: &HashMap<String, String>) -> bool {
+        self.left.matches_key_value(values) || self.right.matches_key_value(values)
+    }
+}
+
+impl<L, R> Matcher for Or<L, R>
+where
+    L: Matcher,
+    R: Matcher,
+{
+    fn matches_value(&self, value: &str) -> bool {
+        self.left.matches_value(value) || self.right.matches_value(value)
     }
 }
 
@@ -42,6 +124,12 @@ impl Matcher for &str {
 
 impl Matcher for () {
     fn matches_value(&self, _value: &str) -> bool {
+        false
+    }
+}
+
+impl KeyValueMatcher for () {
+    fn matches_key_value(&self, _values: &HashMap<String, String>) -> bool {
         false
     }
 }
@@ -75,12 +163,34 @@ where
     }
 }
 
+impl<M> KeyValueMatcher for Option<M>
+where
+    M: KeyValueMatcher,
+{
+    fn matches_key_value(&self, values: &HashMap<String, String>) -> bool {
+        if let Some(matcher) = self {
+            matcher.matches_key_value(values)
+        } else {
+            false
+        }
+    }
+}
+
 impl<M> Matcher for Box<M>
 where
     M: Matcher,
 {
     fn matches_value(&self, value: &str) -> bool {
         (**self).matches_value(value)
+    }
+}
+
+impl<M> KeyValueMatcher for Box<M>
+where
+    M: KeyValueMatcher,
+{
+    fn matches_key_value(&self, values: &HashMap<String, String>) -> bool {
+        (**self).matches_key_value(values)
     }
 }
 
@@ -93,28 +203,150 @@ where
     }
 }
 
-impl<M> Matcher for Vec<M>
+impl<M> KeyValueMatcher for &M
 where
+    M: KeyValueMatcher,
+{
+    fn matches_key_value(&self, values: &HashMap<String, String>) -> bool {
+        (**self).matches_key_value(values)
+    }
+}
+
+impl<S, M> KeyValueMatcher for (S, M)
+where
+    S: Matcher,
     M: Matcher,
 {
-    fn matches_value(&self, value: &str) -> bool {
-        self.iter().all(|matcher| matcher.matches_value(value))
+    fn matches_key_value(&self, values: &HashMap<String, String>) -> bool {
+        let (key_matcher, value_matcher) = self;
+        values
+            .iter()
+            .any(|(k, v)| key_matcher.matches_value(k) && value_matcher.matches_value(v))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::matcher::{Asterisk, Matcher as _};
+    use std::collections::HashMap;
+
+    use crate::matcher::{And, Any, KeyValueMatcher as _, Matcher as _, Or};
+
+    fn forwarded_map(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
 
     #[test]
-    fn matcher() {
-        assert!("abc".matches_value("abc"));
-        assert!(!None::<String>.matches_value("abc"));
-        assert!(Some("xyz").matches_value("xyz"));
-        assert!(!().matches_value("def"));
-        assert!(!vec!["abc", "def"].matches_value("abc"));
-        assert!(!"Nepal".matches_value("nepal"));
-        assert!(!"ABC".matches_value("abc"));
-        assert!(Asterisk.matches_value("random_val"));
+    fn any_host_always_matches() {
+        let m = Any;
+        assert!(m.matches_value("example.com"));
+        assert!(m.matches_value("random"));
+    }
+
+    #[test]
+    fn any_forwarded_always_matches() {
+        let m = Any;
+        let data = forwarded_map(&[("by", "server1")]);
+        assert!(m.matches_key_value(&data));
+    }
+
+    #[test]
+    fn string_and_str_matchers() {
+        let m1 = "example.com".to_string();
+        let m2 = "example.com";
+        assert!(m1.matches_value("example.com"));
+        assert!(!m1.matches_value("other.com"));
+        assert!(m2.matches_value("example.com"));
+        assert!(!m2.matches_value("other.com"));
+    }
+
+    #[test]
+    fn unit_matchers_never_match() {
+        let host_m: () = ();
+        let fwd_m: () = ();
+        assert!(!host_m.matches_value("anything"));
+        let data = forwarded_map(&[("foo", "bar")]);
+        assert!(!fwd_m.matches_key_value(&data));
+    }
+
+    #[test]
+    fn and_matcher() {
+        let m1 = "example.com".to_string();
+        let m2 = "example.com";
+        let and = And::new(m1, m2);
+        assert!(and.matches_value("example.com"));
+        assert!(!and.matches_value("other.com"));
+    }
+
+    #[test]
+    fn or_matcher() {
+        let m1 = "foo.com".to_string();
+        let m2 = "bar.com".to_string();
+        let or = Or::new(m1, m2);
+        assert!(or.matches_value("foo.com"));
+        assert!(or.matches_value("bar.com"));
+        assert!(!or.matches_value("baz.com"));
+    }
+
+    #[test]
+    fn option_and_box_wrappers() {
+        let some: Option<String> = Some("host.com".to_string());
+        assert!(some.matches_value("host.com"));
+        assert!(!some.matches_value("other.com"));
+
+        let none: Option<String> = None;
+        assert!(!none.matches_value("host.com"));
+
+        let boxed: Box<String> = Box::new("host.com".to_string());
+        assert!(boxed.matches_value("host.com"));
+    }
+
+    #[test]
+    fn forwarded_tuple_matcher() {
+        let fwd = ("by", "proxy1");
+        let data = forwarded_map(&[("by", "proxy1"), ("host", "example.com")]);
+        assert!(fwd.matches_key_value(&data));
+
+        let data2 = forwarded_map(&[("by", "proxy2")]);
+        assert!(!fwd.matches_key_value(&data2));
+    }
+
+    #[test]
+    fn forwarded_and_or_matchers() {
+        let m1 = ("by", "proxy1");
+        let m2 = ("sig", "123");
+        let and = And::new(m1, m2);
+        let or = Or::new(m1, m2);
+
+        let data = forwarded_map(&[("by", "proxy1"), ("sig", "123")]);
+        assert!(and.matches_key_value(&data));
+        assert!(or.matches_key_value(&data));
+
+        let data2 = forwarded_map(&[("by", "proxy2"), ("sig", "123")]);
+        assert!(!and.matches_key_value(&data2));
+        assert!(or.matches_key_value(&data2));
+    }
+
+    #[cfg(feature = "regex")]
+    #[test]
+    fn regex_matcher() {
+        use regex::Regex;
+
+        let m = Regex::new(r"^.*\.com$").unwrap();
+        assert!(m.matches_value("example.com"));
+        assert!(!m.matches_value("example.org"));
+    }
+
+    #[cfg(feature = "wildcard")]
+    #[test]
+    fn wildcard_matcher() {
+        use wildmatch::WildMatch;
+
+        let m = WildMatch::new("*.example.com");
+        assert!(m.matches_value("api.example.com"));
+        assert!(m.matches_value("www.example.com"));
+        assert!(!m.matches_value("example.org"));
     }
 }


### PR DESCRIPTION
- add support for dynamic matcher
- add support for matching both key and value when checking forwarded header
- add helper struct to implement And, Or matcher
- remove support for vec due to ambiguity
- only support one matcher for host and forwarded for multiple use And or Or